### PR TITLE
Fix wallet update SQL and add tests

### DIFF
--- a/src/utils/economy.py
+++ b/src/utils/economy.py
@@ -39,6 +39,7 @@ class EconomyUtils:
             "INSERT INTO bank VALUES(%s, %s, %s, %s)", (user_id, 0, 100, 25000)
         )
         conn.commit()
+        cursor.close()
         conn.close()
         return
 
@@ -54,6 +55,8 @@ class EconomyUtils:
             cls.create_wallet(user_id)
             return 0, 100, 25000
         wallet, bank, maxbank = data[0], data[1], data[2]
+        cursor.close()
+        conn.close()
         return wallet, bank, maxbank
 
     @classmethod
@@ -66,8 +69,9 @@ class EconomyUtils:
             cls.create_wallet(user_id)
             return 0
         cursor.execute(
-            "UPDATE bank SET wallet = %s, WHERE user_id = %s",
+            "UPDATE bank SET wallet = %s WHERE user_id = %s",
             (data[0] + amount, user_id),
         )
         conn.commit()
+        cursor.close()
         conn.close()

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,1 +1,39 @@
-# TODO: complete this
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.modules['psycopg'] = MagicMock()
+sys.modules['dotenv'] = MagicMock()
+
+import pytest
+
+from src.utils.economy import EconomyUtils
+
+
+def normalize_whitespace(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def test_update_wallet():
+    with patch("src.utils.economy.psycopg.connect") as mock_connect:
+        mock_conn = MagicMock()
+        mock_cursor = mock_conn.cursor.return_value
+        mock_cursor.fetchone.return_value = [10]
+        mock_connect.return_value = mock_conn
+
+        EconomyUtils.update_wallet(user_id=1, amount=5)
+
+        # Verify the SELECT and UPDATE queries were executed
+        select_call = mock_cursor.execute.call_args_list[0]
+        assert normalize_whitespace(select_call.args[0]) == normalize_whitespace(
+            "SELECT wallet FROM bank WHERE user_id = %s"
+        )
+
+        update_call = mock_cursor.execute.call_args_list[1]
+        assert normalize_whitespace(update_call.args[0]) == normalize_whitespace(
+            "UPDATE bank SET wallet = %s WHERE user_id = %s"
+        )
+        assert update_call.args[1] == (15, 1)
+
+        mock_cursor.close.assert_called_once()
+        mock_conn.commit.assert_called_once()
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- fix SQL syntax in `EconomyUtils.update_wallet`
- close DB cursors properly
- stub external dependencies in tests
- add unit test for `update_wallet`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3b2fa1548332a19d6c089ac30536