### PR TITLE
Add tests for command decorators

### DIFF
--- a/tests/command_utils.py
+++ b/tests/command_utils.py
@@ -1,0 +1,8 @@
+import ast
+
+
+def get_function_def(tree: ast.AST, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None

--- a/tests/test_fakeperms_commands.py
+++ b/tests/test_fakeperms_commands.py
@@ -1,0 +1,33 @@
+import ast
+import os
+import pytest
+
+from .command_utils import get_function_def
+
+FILEPATH = "src/cogs/fakeperms.py"
+COMMANDS = [
+    ("mod_fakeperms", "fakeperms"),
+    ("fp_grant_permission", "grant"),
+    ("fp_revoke_permission", "revoke"),
+    ("fp_list_permissions", "list"),
+]
+
+@pytest.mark.parametrize("func_name,command_name", COMMANDS)
+def test_fakeperms_command_decorators(func_name: str, command_name: str):
+    assert os.path.exists(FILEPATH), f"{FILEPATH} does not exist"
+    with open(FILEPATH, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=FILEPATH)
+
+    func = get_function_def(tree, func_name)
+    assert func is not None, f"Function {func_name} not found in {FILEPATH}"
+
+    found = False
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Call) and hasattr(dec.func, "attr"):
+            if dec.func.attr in {"hybrid_command", "hybrid_group", "command"}:
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value == command_name:
+                            found = True
+                            break
+    assert found, f"{func_name} missing decorator name '{command_name}'"

--- a/tests/test_games_commands.py
+++ b/tests/test_games_commands.py
@@ -1,0 +1,31 @@
+import ast
+import os
+import pytest
+
+from .command_utils import get_function_def
+
+FILEPATH = "src/cogs/games.py"
+COMMANDS = [
+    ("games_diceroll", "diceroll"),
+    ("games_setup_counting", "csetup"),
+]
+
+@pytest.mark.parametrize("func_name,command_name", COMMANDS)
+def test_games_command_decorators(func_name: str, command_name: str):
+    assert os.path.exists(FILEPATH), f"{FILEPATH} does not exist"
+    with open(FILEPATH, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=FILEPATH)
+
+    func = get_function_def(tree, func_name)
+    assert func is not None, f"Function {func_name} not found in {FILEPATH}"
+
+    found = False
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Call) and hasattr(dec.func, "attr"):
+            if dec.func.attr in {"hybrid_command", "hybrid_group", "command"}:
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value == command_name:
+                            found = True
+                            break
+    assert found, f"{func_name} missing decorator name '{command_name}'"

--- a/tests/test_moderation_commands.py
+++ b/tests/test_moderation_commands.py
@@ -1,0 +1,34 @@
+import ast
+import os
+import pytest
+
+from .command_utils import get_function_def
+
+FILEPATH = "src/cogs/moderation.py"
+COMMANDS = [
+    ("moderator_kick", "kick"),
+    ("moderator_ban", "ban"),
+    ("moderator_unban", "unban"),
+    ("moderator_mute_or_timeout", "mute"),
+    ("moderator_unmute_or_untimeout", "unmute"),
+]
+
+@pytest.mark.parametrize("func_name,command_name", COMMANDS)
+def test_moderation_command_decorators(func_name: str, command_name: str):
+    assert os.path.exists(FILEPATH), f"{FILEPATH} does not exist"
+    with open(FILEPATH, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=FILEPATH)
+
+    func = get_function_def(tree, func_name)
+    assert func is not None, f"Function {func_name} not found in {FILEPATH}"
+
+    found = False
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Call) and hasattr(dec.func, "attr"):
+            if dec.func.attr in {"hybrid_command", "hybrid_group", "command"}:
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value == command_name:
+                            found = True
+                            break
+    assert found, f"{func_name} missing decorator name '{command_name}'"

--- a/tests/test_music_commands.py
+++ b/tests/test_music_commands.py
@@ -1,0 +1,36 @@
+import ast
+import os
+import pytest
+
+from .command_utils import get_function_def
+
+FILEPATH = "src/cogs/music.py"
+COMMANDS = [
+    ("music_play", "play"),
+    ("music_skip", "skip"),
+    ("music_play_pause", "toggle"),
+    ("music_volume", "volume"),
+    ("music_disconnect", "disconnect"),
+    ("music_loop_track", "loop"),
+    ("music_shuffle_queue", "shuffle"),
+]
+
+@pytest.mark.parametrize("func_name,command_name", COMMANDS)
+def test_music_command_decorators(func_name: str, command_name: str):
+    assert os.path.exists(FILEPATH), f"{FILEPATH} does not exist"
+    with open(FILEPATH, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=FILEPATH)
+
+    func = get_function_def(tree, func_name)
+    assert func is not None, f"Function {func_name} not found in {FILEPATH}"
+
+    found = False
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Call) and hasattr(dec.func, "attr"):
+            if dec.func.attr in {"hybrid_command", "hybrid_group", "command"}:
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value == command_name:
+                            found = True
+                            break
+    assert found, f"{func_name} missing decorator name '{command_name}'"

--- a/tests/test_utils_commands.py
+++ b/tests/test_utils_commands.py
@@ -1,0 +1,30 @@
+import ast
+import os
+import pytest
+
+from .command_utils import get_function_def
+
+FILEPATH = "src/cogs/utils.py"
+COMMANDS = [
+    ("utilities_ping", "ping"),
+]
+
+@pytest.mark.parametrize("func_name,command_name", COMMANDS)
+def test_utils_command_decorators(func_name: str, command_name: str):
+    assert os.path.exists(FILEPATH), f"{FILEPATH} does not exist"
+    with open(FILEPATH, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename=FILEPATH)
+
+    func = get_function_def(tree, func_name)
+    assert func is not None, f"Function {func_name} not found in {FILEPATH}"
+
+    found = False
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Call) and hasattr(dec.func, "attr"):
+            if dec.func.attr in {"hybrid_command", "hybrid_group", "command"}:
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        if kw.value.value == command_name:
+                            found = True
+                            break
+    assert found, f"{func_name} missing decorator name '{command_name}'"


### PR DESCRIPTION
## Summary
- split command decorator tests by cog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688460cf6abc8332a3b1336c8184d4d1